### PR TITLE
fix dependency restrictions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,8 +64,8 @@ DEPENDENCIES
   bundler (~> 2.0.1)
   report_factory-rspec!
   rubocop (~> 0.63.1)
-  simplecov (>= 0.16.1)
-  webmock (~> 3.5.1)
+  simplecov (~> 0.16)
+  webmock (~> 3.5)
 
 BUNDLED WITH
    2.0.1

--- a/report_factory-rspec.gemspec
+++ b/report_factory-rspec.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rspec', '~> 3.5'
 
   spec.add_development_dependency 'rubocop', '~> 0.63.1'
-  spec.add_development_dependency 'simplecov', '>= 0.16.1'
-  spec.add_development_dependency 'webmock', '~> 3.5.1'
+  spec.add_development_dependency 'simplecov', '~> 0.16'
+  spec.add_development_dependency 'webmock', '~> 3.5'
 end


### PR DESCRIPTION
Fixed warnings:
```
WARNING:  open-ended dependency on simplecov (>= 0.16.1, development) is not recommended
  if simplecov is semantically versioned, use:
    add_development_dependency 'simplecov', '~> 0.16', '>= 0.16.1'
WARNING:  pessimistic dependency on webmock (~> 3.5.1, development) may be overly strict
  if webmock is semantically versioned, use:
    add_development_dependency 'webmock', '~> 3.5', '>= 3.5.1'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```